### PR TITLE
Fix crash when no options are passed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(opts) {
   // Added Angular after data. See https://github.com/mdo/code-guide/issues/106
-  var orderList = opts.order || ['class', 'id', 'name', 'data', 'ng', 'src', 'for', 'type', 'href', 'values', 'title', 'alt', 'role', 'aria'];
+  var orderList = opts && opts.order || ['class', 'id', 'name', 'data', 'ng', 'src', 'for', 'type', 'href', 'values', 'title', 'alt', 'role', 'aria'];
 
   return function(tree) {
     tree.walk(function(node) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(opts) {
   // Added Angular after data. See https://github.com/mdo/code-guide/issues/106
-  var orderList = opts && opts.order || ['class', 'id', 'name', 'data', 'ng', 'src', 'for', 'type', 'href', 'values', 'title', 'alt', 'role', 'aria'];
+  var orderList = (opts && opts.order) || ['class', 'id', 'name', 'data', 'ng', 'src', 'for', 'type', 'href', 'values', 'title', 'alt', 'role', 'aria'];
 
   return function(tree) {
     tree.walk(function(node) {


### PR DESCRIPTION
If nothing is passed to the plugin, it crashes on line 3 trying to read undefined. Propose fix by checking options exists, before trying to read. This allows us to fall back on the default and no crash if the options are malformed, or missing.
