### PR TITLE
Add ability to specify where the unsorted properties are placed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,21 @@ You can also use this plugin in the PostHTML plugin to [Gulp](https://www.npmjs.
 #### order
 
   * Type: `string[]`
+  * Use `$unknown$` to specify where the unsorted attributes are placed
   * Default: http://codeguide.co/#html-attribute-order
+  
+```json
+{
+  "order": [
+    "class", "id", "name",
+    "data", "ng", "src",
+    "for", "type", "href",
+    "values", "title", "alt",
+    "role", "aria",
+    "$unknown$"
+  ]
+}
+```
 
 An array of attributes in the correct order.
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ You can also use this plugin in the PostHTML plugin to [Gulp](https://www.npmjs.
 #### order
 
   * Type: `string[]`
-  * Use `$unknown$` to specify where the unsorted attributes are placed
+  * Info:
+    * Strings are turned into [Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+    * Use `$unknown$` to specify where the unsorted attributes are placed
   * Default: http://codeguide.co/#html-attribute-order
   
 ```json
 {
   "order": [
     "class", "id", "name",
-    "data", "ng", "src",
+    "data-.+", "ng-.+", "src",
     "for", "type", "href",
     "values", "title", "alt",
-    "role", "aria",
+    "role", "aria-.+",
     "$unknown$"
   ]
 }

--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ module.exports = function(opts) {
     'data', 'ng', 'src',
     'for', 'type', 'href',
     'values', 'title', 'alt',
-    'role', 'aria'
+    'role', 'aria',
+    '$unknown$'
   ];
 
   // A RegExp's for filtering and sorting
-  var orderListFilterRegExp = new RegExp('(' + orderList.join('|') + ')');
+  var orderListFilterRegExp = new RegExp('^(' + orderList.join('|') + ')');
   var orderListRegExp = orderList.map(function(item) {
     return new RegExp('^' + item);
   });
@@ -21,39 +22,63 @@ module.exports = function(opts) {
       }
 
       var attrs = Object.keys(node.attrs);
-      if (attrs.length === 1) {
+
+      if (attrs.length === 1 || orderList.length === 0) {
         return node;
       }
 
+      var sortableAttrs = [];
       var sortedAttrs = [];
       var notSortedAttrs = [];
-      attrs = attrs
-        // The separation of the attributes on a sortable and not sortable
+      var notSortedAttrsIndex = orderList.indexOf('$unknown$');
+      var finalAttrs = {};
+
+      if (notSortedAttrsIndex === -1) {
+        notSortedAttrsIndex = orderList.length;
+      }
+
+      sortableAttrs = attrs
+        // The separation of the attributes on a sortable and not sortable basis
         .filter(function(attr) {
           if (orderListFilterRegExp.test(attr)) {
             return true;
           }
-          notSortedAttrs.push(attr);
-          return false;
-        })
-        .sort(function(a, b) {
-          orderListRegExp.forEach(function(re, index) {
-            if (re.test(a)) {
-              a = index;
-            }
-            if (re.test(b)) {
-              b = index;
-            }
-          });
 
-          return a - b;
-        })
-        .concat(notSortedAttrs)
-        .forEach(function(attr) {
-          sortedAttrs[attr] = (node.attrs[attr]) ? node.attrs[attr] : true;
+          notSortedAttrs.push(attr);
+
+          return false;
         });
 
-      node.attrs = sortedAttrs;
+      sortedAttrs = orderListRegExp
+        // match to each position
+        .map(function(regex) {
+          return sortableAttrs
+            // attrs that belong in this regex group
+            .filter(function(attr) {
+              return regex.test(attr);
+            })
+            // alpha desc sort each group
+            .sort(function(a, b) {
+              return typeof a.localeCompare === 'function' ? a.localeCompare(b) : a - b;
+            });
+        })
+        // remove empty groups
+        .filter(function(group) {
+          return group.length > 0;
+        });
+
+      sortedAttrs
+        // put the non-sorted attributes in desired slot
+        .splice(notSortedAttrsIndex, 0, notSortedAttrs);
+
+      sortedAttrs.forEach(function(group) {
+        group.forEach(function(attr) {
+          finalAttrs[attr] = (node.attrs[attr]) ? node.attrs[attr] : true;
+        });
+      });
+
+      node.attrs = finalAttrs;
+
       return node;
     });
 

--- a/index.js
+++ b/index.js
@@ -2,17 +2,17 @@ module.exports = function(opts) {
   // Added Angular after data. See https://github.com/mdo/code-guide/issues/106
   var orderList = (opts && opts.order) || [
     'class', 'id', 'name',
-    'data', 'ng', 'src',
+    'data-.+', 'ng-.+', 'src',
     'for', 'type', 'href',
     'values', 'title', 'alt',
-    'role', 'aria',
+    'role', 'aria-.+',
     '$unknown$'
   ];
 
   // A RegExp's for filtering and sorting
-  var orderListFilterRegExp = new RegExp('^(' + orderList.join('|') + ')');
+  var orderListFilterRegExp = new RegExp('^(' + orderList.join('|') + ')$');
   var orderListRegExp = orderList.map(function(item) {
-    return new RegExp('^' + item);
+    return new RegExp('^' + item + '$');
   });
 
   return function(tree) {

--- a/test.js
+++ b/test.js
@@ -86,3 +86,19 @@ it('Custom config bug (issue #12)', function(done) {
     done
   );
 });
+
+it('Put unsorted in specific location', function(done) {
+  test(
+    '<img width="20" src="../images/image.png" height="40" alt="image" class="cls" id="id2">',
+    '<img src="../images/image.png" id="id2" width="20" height="40" alt="image" class="cls">',
+    {
+      order: [
+        'src',
+        'id',
+        '$unknown$',
+        'class'
+      ]
+    },
+    done
+  );
+});


### PR DESCRIPTION
### Summary
Gives users the ability to designate where in the new attribute order the unspecified attributes should go.

Also fixes an error where identifiers like `id` would match `width`.

### Info
I gave it the name `$unknown$` but I'm open to suggestions on the identifier.

### Example Use-Case
Always keep event handlers at the last position.
```json
{
  "order": [
    "id",
    "$unknown$",
    "on-.+?"
  ]
}
```
```html
<select
  id="safe-select"
  name="safe-select"
  class="[[classes]]"
  value="{{value::change}}"
  required="[[required]]"
  disabled="[[disabled]]"
  on-focus="[[eventHandler]]">
</select>
```